### PR TITLE
enable building on Windows

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,7 +1,7 @@
 {
   "targets": [
     {
-      "target_name": "compressor",
+      "target_name": "compressor.node",
       "include_dirs": [
         "<!(node -e \"require('nan')\")",
         "deps/zstd/lib",
@@ -34,7 +34,7 @@
       ]
     },
     {
-      "target_name": "decompressor",
+      "target_name": "decompressor.node",
       "include_dirs": [
         "<!(node -e \"require('nan')\")",
         "deps/zstd/lib",


### PR DESCRIPTION
Currently Visual Studio borkes because the dependency and the wrapper are both named the same:
```
LINK : fatal error LNK1149: output filename matches input filename 'D:\code\4node\test-node-gyp\node_modules\node-zstd\build\Release\compressor.lib' [D:\code\4node\test-node-gyp\node_modules\node-zstd\build\comp ressor.vcxproj]
```
<details>
<summary>full node-gyp output</summary>
```cmd
D:\code\4node\test-node-gyp$ npm i --no-link node-zstd
npm http request GET https://registry.npmjs.org/node-zstd
npm http 200 https://registry.npmjs.org/node-zstd
npm http fetch GET https://registry.npmjs.org/node-zstd/-/node-zstd-2.0.1.tgz
npm http fetch 200 https://registry.npmjs.org/node-zstd/-/node-zstd-2.0.1.tgz
npm http request GET https://registry.npmjs.org/bindings
npm http request GET https://registry.npmjs.org/nan
npm http 304 https://registry.npmjs.org/bindings
npm http 304 https://registry.npmjs.org/nan

> node-zstd@2.0.1 install D:\code\4node\test-node-gyp\node_modules\node-zstd
> node-gyp rebuild


@CLINK_PROMPTD:\code\4node\test-node-gyp\node_modules\node-zstd$ if not defined npm_config_node_gyp (node "D:\bin\dev\node\node_modules\npm\bin\node-gyp-bin\\..\..\node_modules\node-gyp\bin\node-gyp.js" rebuild )
  else (node "" rebuild )
Building the projects in this solution one at a time. To enable parallel build, please add the "/m" switch.
  entropy_common.c
  fse_decompress.c
  xxhash.c
  zstd_common.c
  fse_compress.c
  huf_compress.c
  zbuff_compress.c
  zstd_compress.c
  win_delay_load_hook.cc
  compressor.vcxproj -> D:\code\4node\test-node-gyp\node_modules\node-zstd\build\Release\\compressor.lib
  stream_coder.cc
  allocator.cc
  compressor_index.cc
  stream_compressor.cc
..\src\common\allocator.cc(38): warning C4146: unary minus operator applied to unsigned type, result still unsigned [D:\code\4node\test-node-gyp\node_modules\node-zstd\build\compressor.vcxproj]
..\src\common\allocator.cc(49): warning C4244: 'argument': conversion from 'int64_t' to 'int', possible loss of data [D:\code\4node\test-node-gyp\node_modules\node-zstd\build\compressor.vcxproj]
..\src\compress\stream_compressor.cc(95): warning C4996: 'v8::Function::NewInstance': was declared deprecated [D:\code\4node\test-node-gyp\node_modules\node-zstd\build\compressor.vcxproj]
  c:\users\refael\.node-gyp\7.9.0\include\node\v8.h(3658): note: see declaration of 'v8::Function::NewInstance'
d:\code\4node\test-node-gyp\node_modules\nan\nan_new.h(208): warning C4244: 'argument': conversion from 'size_t' to 'double', possible loss of data (compiling source file ..\src\compress\stream_compressor.cc) [D :\code\4node\test-node-gyp\node_modules\node-zstd\build\compressor.vcxproj]
  ..\src\compress\stream_compressor.cc(100): note: see reference to function template instantiation 'v8::Local<v8::Number> Nan::New<v8::Number,::size_t>(A0)' being compiled
          with
          [
              A0=::size_t
          ]
  stream_compress_worker.cc
  win_delay_load_hook.cc
LINK : fatal error LNK1149: output filename matches input filename 'D:\code\4node\test-node-gyp\node_modules\node-zstd\build\Release\compressor.lib' [D:\code\4node\test-node-gyp\node_modules\node-zstd\build\comp ressor.vcxproj]
  entropy_common.c
  fse_decompress.c
  xxhash.c
  zstd_common.c
  huf_decompress.c
  zbuff_decompress.c
  zstd_decompress.c
  win_delay_load_hook.cc
  decompressor.vcxproj -> D:\code\4node\test-node-gyp\node_modules\node-zstd\build\Release\\decompressor.lib
  stream_coder.cc
  allocator.cc
  decompressor_index.cc
  stream_decompressor.cc
..\src\common\allocator.cc(38): warning C4146: unary minus operator applied to unsigned type, result still unsigned [D:\code\4node\test-node-gyp\node_modules\node-zstd\build\decompressor.vcxproj]
..\src\common\allocator.cc(49): warning C4244: 'argument': conversion from 'int64_t' to 'int', possible loss of data [D:\code\4node\test-node-gyp\node_modules\node-zstd\build\decompressor.vcxproj]
..\src\decompress\stream_decompressor.cc(90): warning C4996: 'v8::Function::NewInstance': was declared deprecated [D:\code\4node\test-node-gyp\node_modules\node-zstd\build\decompressor.vcxproj]
  c:\users\refael\.node-gyp\7.9.0\include\node\v8.h(3658): note: see declaration of 'v8::Function::NewInstance'
d:\code\4node\test-node-gyp\node_modules\nan\nan_new.h(208): warning C4244: 'argument': conversion from 'size_t' to 'double', possible loss of data (compiling source file ..\src\decompress\stream_decompressor.cc ) [D:\code\4node\test-node-gyp\node_modules\node-zstd\build\decompressor.vcxproj]
  ..\src\decompress\stream_decompressor.cc(95): note: see reference to function template instantiation 'v8::Local<v8::Number> Nan::New<v8::Number,::size_t>(A0)' being compiled
          with
          [
              A0=::size_t
          ]
  stream_decompress_worker.cc
  win_delay_load_hook.cc
LINK : fatal error LNK1149: output filename matches input filename 'D:\code\4node\test-node-gyp\node_modules\node-zstd\build\Release\decompressor.lib' [D:\code\4node\test-node-gyp\node_modules\node-zstd\build\de compressor.vcxproj]
gyp ERR! build error
gyp ERR! stack Error: `D:\bin\dev\VS\2017\BuildTools\MSBuild\15.0\Bin\MSBuild.exe` failed with exit code: 1
gyp ERR! stack     at ChildProcess.onExit (D:\code\3party\node-gyp\lib\build.js:285:23)
gyp ERR! stack     at emitTwo (events.js:106:13)
gyp ERR! stack     at ChildProcess.emit (events.js:194:7)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:215:12)
gyp ERR! System Windows_NT 10.0.15063
gyp ERR! command "C:\\bin\\dev\\node\\node.exe" "D:\\bin\\dev\\node\\node_modules\\npm\\node_modules\\node-gyp\\bin\\node-gyp.js" "rebuild"
gyp ERR! cwd D:\code\4node\test-node-gyp\node_modules\node-zstd
gyp ERR! node -v v7.9.0
gyp ERR! node-gyp -v v3.6.0
gyp ERR! not ok
npm WARN test-node-gyp@1.0.0 No description
npm WARN test-node-gyp@1.0.0 No repository field.
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! node-zstd@2.0.1 install: `node-gyp rebuild`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the node-zstd@2.0.1 install script 'node-gyp rebuild'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the node-zstd package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     node-gyp rebuild
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs node-zstd
npm ERR! Or if that isn't available, you can get their info via:
npm ERR!     npm owner ls node-zstd
npm ERR! There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\bin\var\npm-cache\_logs\2017-04-27T21_24_58_088Z-debug.log
```
</details>